### PR TITLE
feat(NAT-13): add Experience link to footer across all pages

### DIFF
--- a/Amazon.html
+++ b/Amazon.html
@@ -184,6 +184,7 @@
       <ul class="footer-links">
         <li><a href="index.html#header" class="scrolly">Home</a></li>
         <li><a href="index.html#one" class="scrolly">About</a></li>
+        <li><a href="index.html#three" class="scrolly">Experience</a></li>
         <li><a href="index.html#four" class="scrolly">Projects</a></li>
         <li><a href="https://www.linkedin.com/in/natantaklilu/" class="contact">Contact</a></li>
       </ul>

--- a/Anomaly_Detection.html
+++ b/Anomaly_Detection.html
@@ -179,6 +179,7 @@
       <ul class="footer-links">
         <li><a href="index.html#header" class="scrolly">Home</a></li>
         <li><a href="index.html#one" class="scrolly">About</a></li>
+        <li><a href="index.html#three" class="scrolly">Experience</a></li>
         <li><a href="index.html#four" class="scrolly">Projects</a></li>
         <li><a href="https://www.linkedin.com/in/natantaklilu/" class="contact">Contact</a></li>
       </ul>

--- a/Bridge_Quote_Simulation.html
+++ b/Bridge_Quote_Simulation.html
@@ -196,6 +196,7 @@
       <ul class="footer-links">
         <li><a href="index.html#header" class="scrolly">Home</a></li>
         <li><a href="index.html#one" class="scrolly">About</a></li>
+        <li><a href="index.html#three" class="scrolly">Experience</a></li>
         <li><a href="index.html#four" class="scrolly">Projects</a></li>
         <li><a href="https://www.linkedin.com/in/natantaklilu/" class="contact">Contact</a></li>
       </ul>

--- a/CU_GeoData.html
+++ b/CU_GeoData.html
@@ -167,6 +167,7 @@
       <ul class="footer-links">
         <li><a href="index.html#header" class="scrolly">Home</a></li>
         <li><a href="index.html#one" class="scrolly">About</a></li>
+        <li><a href="index.html#three" class="scrolly">Experience</a></li>
         <li><a href="index.html#four" class="scrolly">Projects</a></li>
         <li><a href="https://www.linkedin.com/in/natantaklilu/" class="contact">Contact</a></li>
       </ul>

--- a/CamlChess.html
+++ b/CamlChess.html
@@ -148,6 +148,7 @@
       <ul class="footer-links">
         <li><a href="index.html#header" class="scrolly">Home</a></li>
         <li><a href="index.html#one" class="scrolly">About</a></li>
+        <li><a href="index.html#three" class="scrolly">Experience</a></li>
         <li><a href="index.html#four" class="scrolly">Projects</a></li>
         <li><a href="https://www.linkedin.com/in/natantaklilu/" class="contact">Contact</a></li>
       </ul>

--- a/Coinbase.html
+++ b/Coinbase.html
@@ -182,6 +182,7 @@
       <ul class="footer-links">
         <li><a href="index.html#header" class="scrolly">Home</a></li>
         <li><a href="index.html#one" class="scrolly">About</a></li>
+        <li><a href="index.html#three" class="scrolly">Experience</a></li>
         <li><a href="index.html#four" class="scrolly">Projects</a></li>
         <li><a href="https://www.linkedin.com/in/natantaklilu/" class="contact">Contact</a></li>
       </ul>

--- a/Cornell_TA.html
+++ b/Cornell_TA.html
@@ -172,6 +172,7 @@
       <ul class="footer-links">
         <li><a href="index.html#header" class="scrolly">Home</a></li>
         <li><a href="index.html#one" class="scrolly">About</a></li>
+        <li><a href="index.html#three" class="scrolly">Experience</a></li>
         <li><a href="index.html#four" class="scrolly">Projects</a></li>
         <li><a href="https://www.linkedin.com/in/natantaklilu/" class="contact">Contact</a></li>
       </ul>

--- a/Tax_Lot_Split.html
+++ b/Tax_Lot_Split.html
@@ -175,6 +175,7 @@
       <ul class="footer-links">
         <li><a href="index.html#header" class="scrolly">Home</a></li>
         <li><a href="index.html#one" class="scrolly">About</a></li>
+        <li><a href="index.html#three" class="scrolly">Experience</a></li>
         <li><a href="index.html#four" class="scrolly">Projects</a></li>
         <li><a href="https://www.linkedin.com/in/natantaklilu/" class="contact">Contact</a></li>
       </ul>

--- a/assets/css/main.css
+++ b/assets/css/main.css
@@ -4209,8 +4209,11 @@ body.is-touch #banner {
 .footer-links {
 	display: flex;
 	list-style: none;
-	margin: 0 0;
+	margin: 0;
 	padding: 0;
+	flex: 1;
+	justify-content: flex-start;
+	align-items: center;
 }
 
 .footer-links li {
@@ -4233,13 +4236,19 @@ body.is-touch #banner {
 
 /* Styling for the centered image */
 .footer-logo {
-	text-align: center;
+	flex: 1;
+	display: flex;
+	justify-content: center;
+	align-items: center;
 }
 
 /* Styling for the right copyright */
 .footer-copyright {
+	flex: 1;
 	font-size: 1em;
-	text-align: right;
+	display: flex;
+	justify-content: flex-end;
+	align-items: center;
 	margin-right: 2em;
 }
 

--- a/index.html
+++ b/index.html
@@ -320,6 +320,7 @@
 			<ul class="footer-links">
 				<li><a href="#header" class="scrolly">Home</a></li>
 				<li><a href="#one" class="scrolly">About</a></li>
+				<li><a href="#three" class="scrolly">Experience</a></li>
 				<li><a href="#four" class="scrolly">Projects</a></li>
 				<!-- Add animation of LinkedIn logo popping out when hovering -->
 				<li><a href="https://www.linkedin.com/in/natantaklilu/" class="contact">Contact</a></li>


### PR DESCRIPTION
﻿## What Changed?
- Added an Experience link to the footer on all 9 pages (index.html and all experience/project sub-pages)
- Footer now reads: Home | About | Experience | Projects | Contact

## Why
The nav bar was previously split into separate Experience and Projects dropdowns (NAT-11), but the footer still only linked to Projects. This makes the footer consistent with the nav structure and gives visitors a quick way to jump to the Experience section from anywhere on the site.

## Files Changed
- index.html
- Coinbase.html
- Amazon.html
- Cornell_TA.html
- CU_GeoData.html
- Tax_Lot_Split.html
- Bridge_Quote_Simulation.html
- Anomaly_Detection.html
- CamlChess.html

## Testing
- [x] Verify footer on homepage scrolls to the Experience section (#three) when clicking Experience
- [x] Verify footer on a sub-page (e.g. Amazon.html) navigates to index.html#three correctly
- [x] Confirm all 5 footer links (Home, About, Experience, Projects, Contact) are present and functional across all pages

## Linear
Closes [NAT-13](https://linear.app/natan-personal/issue/NAT-13/update-footer-links-to-reflect-experience-and-projects-split)
