### PR TITLE
feat(NAT-23): componentize header and footer using Web Components

### DIFF
--- a/Amazon.html
+++ b/Amazon.html
@@ -1,4 +1,4 @@
-<!DOCTYPE HTML>
+﻿<!DOCTYPE HTML>
 <html>
 
 <head>
@@ -17,35 +17,7 @@
   <div id="page-wrapper">
 
     <!-- Header -->
-    <header id="header">
-      <h1 id="logo"><a href="index.html" class="scrolly"><img src="Media/Website_Logo_No_BG.png" height="100%"></a></h1>
-      <nav id="nav">
-        <ul>
-          <li><a href="index.html#one" class="scrolly">About Me</a></li>
-          <li><a href="index.html#two" class="scrolly">Education</a></li>
-          <li>
-            <a href="index.html#three" class="scrolly">Experience ⌵</a>
-            <ul>
-              <li><a href="Coinbase.html" class="scrolly">Coinbase</a></li>
-              <li><a href="#" class="scrolly">Amazon</a></li>
-              <li><a href="CU_GeoData.html" class="scrolly">CU GeoData</a></li>
-              <li><a href="Cornell_TA.html" class="scrolly">Cornell TA</a></li>
-            </ul>
-          </li>
-          <li>
-            <a href="index.html#four" class="scrolly">Projects ⌵</a>
-            <ul>
-              <li><a href="Tax_Lot_Split.html" class="scrolly">Tax Lot Split</a></li>
-              <li><a href="Bridge_Quote_Simulation.html" class="scrolly">Bridge Quote Simulation</a></li>
-              <li><a href="Anomaly_Detection.html" class="scrolly">Anomaly Detection</a></li>
-              <li><a href="CamlChess.html" class="scrolly">CamlChess</a></li>
-              <li><a href="https://github.com/NatanAklilu/SpaceInvaders" class="scrolly">Space Invaders</a></li>
-            </ul>
-          </li>
-          <li><a href="Media/Natan_Aklilu_Resume_2026.pdf" download class="button primary">Resume</a></li>
-        </ul>
-      </nav>
-    </header>
+    <site-nav data-page="amazon"></site-nav>
 
     <!-- Adding a button to help bring user to top of page (using some Javascript)-->
 
@@ -179,30 +151,13 @@
       </div>
     </div>
 
-    <!-- Footer: More navigation linking to other sections-->
-    <footer id="footer">
-      <ul class="footer-links">
-        <li><a href="index.html#header" class="scrolly">Home</a></li>
-        <li><a href="index.html#one" class="scrolly">About</a></li>
-        <li><a href="index.html#three" class="scrolly">Experience</a></li>
-        <li><a href="index.html#four" class="scrolly">Projects</a></li>
-        <li><a href="https://www.linkedin.com/in/natantaklilu/" class="contact">Contact</a></li>
-      </ul>
-
-      <!-- Center: Logo Image -->
-      <div class="footer-logo">
-        <a href="index.html#banner" class="scrolly"><img src="Media/Website_Logo_No_BG.png" height="70em"></a>
-      </div>
-
-      <!-- Right: Copyright Information -->
-      <div class="footer-copyright">
-        &copy; 2026 Natan Aklilu. All rights reserved.
-      </div>
-    </footer>
+    <!-- Footer -->
+    <site-footer data-page="amazon"></site-footer>
 
   </div>
 
   <!-- Scripts -->
+	<script src="assets/js/components.js"></script>
   <script src="assets/js/jquery.min.js"></script>
   <script src="assets/js/jquery.scrolly.min.js"></script>
   <script src="assets/js/jquery.dropotron.min.js"></script>

--- a/Anomaly_Detection.html
+++ b/Anomaly_Detection.html
@@ -1,4 +1,4 @@
-<!DOCTYPE HTML>
+﻿<!DOCTYPE HTML>
 <html>
 
 <head>
@@ -17,35 +17,7 @@
   <div id="page-wrapper">
 
     <!-- Header -->
-    <header id="header">
-      <h1 id="logo"><a href="index.html" class="scrolly"><img src="Media/Website_Logo_No_BG.png" height="100%"></a></h1>
-      <nav id="nav">
-        <ul>
-          <li><a href="index.html#one" class="scrolly">About Me</a></li>
-          <li><a href="index.html#two" class="scrolly">Education</a></li>
-          <li>
-            <a href="index.html#three" class="scrolly">Experience ⌵</a>
-            <ul>
-              <li><a href="Coinbase.html" class="scrolly">Coinbase</a></li>
-              <li><a href="Amazon.html" class="scrolly">Amazon</a></li>
-              <li><a href="CU_GeoData.html" class="scrolly">CU GeoData</a></li>
-              <li><a href="Cornell_TA.html" class="scrolly">Cornell TA</a></li>
-            </ul>
-          </li>
-          <li>
-            <a href="index.html#four" class="scrolly">Projects ⌵</a>
-            <ul>
-              <li><a href="Tax_Lot_Split.html" class="scrolly">Tax Lot Split</a></li>
-              <li><a href="Bridge_Quote_Simulation.html" class="scrolly">Bridge Quote Simulation</a></li>
-              <li><a href="#" class="scrolly">Anomaly Detection</a></li>
-              <li><a href="CamlChess.html" class="scrolly">CamlChess</a></li>
-              <li><a href="https://github.com/NatanAklilu/SpaceInvaders" class="scrolly">Space Invaders</a></li>
-            </ul>
-          </li>
-          <li><a href="Media/Natan_Aklilu_Resume_2026.pdf" download class="button primary">Resume</a></li>
-        </ul>
-      </nav>
-    </header>
+    <site-nav data-page="anomaly"></site-nav>
 
     <!-- Adding a button to help bring user to top of page (using some Javascript)-->
 
@@ -174,30 +146,13 @@
       </div>
     </div>
 
-    <!-- Footer: More navigation linking to other sections-->
-    <footer id="footer">
-      <ul class="footer-links">
-        <li><a href="index.html#header" class="scrolly">Home</a></li>
-        <li><a href="index.html#one" class="scrolly">About</a></li>
-        <li><a href="index.html#three" class="scrolly">Experience</a></li>
-        <li><a href="index.html#four" class="scrolly">Projects</a></li>
-        <li><a href="https://www.linkedin.com/in/natantaklilu/" class="contact">Contact</a></li>
-      </ul>
-
-      <!-- Center: Logo Image -->
-      <div class="footer-logo">
-        <a href="index.html#banner" class="scrolly"><img src="Media/Website_Logo_No_BG.png" height="70em"></a>
-      </div>
-
-      <!-- Right: Copyright Information -->
-      <div class="footer-copyright">
-        &copy; 2026 Natan Aklilu. All rights reserved.
-      </div>
-    </footer>
+    <!-- Footer -->
+    <site-footer data-page="anomaly"></site-footer>
 
   </div>
 
   <!-- Scripts -->
+	<script src="assets/js/components.js"></script>
   <script src="assets/js/jquery.min.js"></script>
   <script src="assets/js/jquery.scrolly.min.js"></script>
   <script src="assets/js/jquery.dropotron.min.js"></script>

--- a/Bridge_Quote_Simulation.html
+++ b/Bridge_Quote_Simulation.html
@@ -1,4 +1,4 @@
-<!DOCTYPE HTML>
+﻿<!DOCTYPE HTML>
 <html>
 
 <head>
@@ -17,35 +17,7 @@
   <div id="page-wrapper">
 
     <!-- Header -->
-    <header id="header">
-      <h1 id="logo"><a href="index.html" class="scrolly"><img src="Media/Website_Logo_No_BG.png" height="100%"></a></h1>
-      <nav id="nav">
-        <ul>
-          <li><a href="index.html#one" class="scrolly">About Me</a></li>
-          <li><a href="index.html#two" class="scrolly">Education</a></li>
-          <li>
-            <a href="index.html#three" class="scrolly">Experience ⌵</a>
-            <ul>
-              <li><a href="Coinbase.html" class="scrolly">Coinbase</a></li>
-              <li><a href="Amazon.html" class="scrolly">Amazon</a></li>
-              <li><a href="CU_GeoData.html" class="scrolly">CU GeoData</a></li>
-              <li><a href="Cornell_TA.html" class="scrolly">Cornell TA</a></li>
-            </ul>
-          </li>
-          <li>
-            <a href="index.html#four" class="scrolly">Projects ⌵</a>
-            <ul>
-              <li><a href="Tax_Lot_Split.html" class="scrolly">Tax Lot Split</a></li>
-              <li><a href="#" class="scrolly">Bridge Quote Simulation</a></li>
-              <li><a href="Anomaly_Detection.html" class="scrolly">Anomaly Detection</a></li>
-              <li><a href="CamlChess.html" class="scrolly">CamlChess</a></li>
-              <li><a href="https://github.com/NatanAklilu/SpaceInvaders" class="scrolly">Space Invaders</a></li>
-            </ul>
-          </li>
-          <li><a href="Media/Natan_Aklilu_Resume_2026.pdf" download class="button primary">Resume</a></li>
-        </ul>
-      </nav>
-    </header>
+    <site-nav data-page="bridge-quote"></site-nav>
 
     <!-- Adding a button to help bring user to top of page (using some Javascript)-->
 
@@ -191,30 +163,13 @@
       </div>
     </div>
 
-    <!-- Footer: More navigation linking to other sections-->
-    <footer id="footer">
-      <ul class="footer-links">
-        <li><a href="index.html#header" class="scrolly">Home</a></li>
-        <li><a href="index.html#one" class="scrolly">About</a></li>
-        <li><a href="index.html#three" class="scrolly">Experience</a></li>
-        <li><a href="index.html#four" class="scrolly">Projects</a></li>
-        <li><a href="https://www.linkedin.com/in/natantaklilu/" class="contact">Contact</a></li>
-      </ul>
-
-      <!-- Center: Logo Image -->
-      <div class="footer-logo">
-        <a href="index.html#banner" class="scrolly"><img src="Media/Website_Logo_No_BG.png" height="70em"></a>
-      </div>
-
-      <!-- Right: Copyright Information -->
-      <div class="footer-copyright">
-        &copy; 2026 Natan Aklilu. All rights reserved.
-      </div>
-    </footer>
+    <!-- Footer -->
+    <site-footer data-page="bridge-quote"></site-footer>
 
   </div>
 
   <!-- Scripts -->
+	<script src="assets/js/components.js"></script>
   <script src="assets/js/jquery.min.js"></script>
   <script src="assets/js/jquery.scrolly.min.js"></script>
   <script src="assets/js/jquery.dropotron.min.js"></script>

--- a/CU_GeoData.html
+++ b/CU_GeoData.html
@@ -1,4 +1,4 @@
-<!DOCTYPE HTML>
+﻿<!DOCTYPE HTML>
 <html>
 
 <head>
@@ -17,35 +17,7 @@
   <div id="page-wrapper">
 
     <!-- Header -->
-    <header id="header">
-      <h1 id="logo"><a href="index.html" class="scrolly"><img src="Media/Website_Logo_No_BG.png" height="100%"></a></h1>
-      <nav id="nav">
-        <ul>
-          <li><a href="index.html#one" class="scrolly">About Me</a></li>
-          <li><a href="index.html#two" class="scrolly">Education</a></li>
-          <li>
-            <a href="index.html#three" class="scrolly">Experience ⌵</a>
-            <ul>
-              <li><a href="Coinbase.html" class="scrolly">Coinbase</a></li>
-              <li><a href="Amazon.html" class="scrolly">Amazon</a></li>
-              <li><a href="#" class="scrolly">CU GeoData</a></li>
-              <li><a href="Cornell_TA.html" class="scrolly">Cornell TA</a></li>
-            </ul>
-          </li>
-          <li>
-            <a href="index.html#four" class="scrolly">Projects ⌵</a>
-            <ul>
-              <li><a href="Tax_Lot_Split.html" class="scrolly">Tax Lot Split</a></li>
-              <li><a href="Bridge_Quote_Simulation.html" class="scrolly">Bridge Quote Simulation</a></li>
-              <li><a href="Anomaly_Detection.html" class="scrolly">Anomaly Detection</a></li>
-              <li><a href="CamlChess.html" class="scrolly">CamlChess</a></li>
-              <li><a href="https://github.com/NatanAklilu/SpaceInvaders" class="scrolly">Space Invaders</a></li>
-            </ul>
-          </li>
-          <li><a href="Media/Natan_Aklilu_Resume_2026.pdf" download class="button primary">Resume</a></li>
-        </ul>
-      </nav>
-    </header>
+    <site-nav data-page="cu-geodata"></site-nav>
 
     <!-- Adding a button to help bring user to top of page (using some Javascript)-->
 
@@ -162,30 +134,13 @@
       </div>
     </div>
 
-    <!-- Footer: More navigation linking to other sections-->
-    <footer id="footer">
-      <ul class="footer-links">
-        <li><a href="index.html#header" class="scrolly">Home</a></li>
-        <li><a href="index.html#one" class="scrolly">About</a></li>
-        <li><a href="index.html#three" class="scrolly">Experience</a></li>
-        <li><a href="index.html#four" class="scrolly">Projects</a></li>
-        <li><a href="https://www.linkedin.com/in/natantaklilu/" class="contact">Contact</a></li>
-      </ul>
-
-      <!-- Center: Logo Image -->
-      <div class="footer-logo">
-        <a href="index.html#banner" class="scrolly"><img src="Media/Website_Logo_No_BG.png" height="70em"></a>
-      </div>
-
-      <!-- Right: Copyright Information -->
-      <div class="footer-copyright">
-        &copy; 2026 Natan Aklilu. All rights reserved.
-      </div>
-    </footer>
+    <!-- Footer -->
+    <site-footer data-page="cu-geodata"></site-footer>
 
   </div>
 
   <!-- Scripts -->
+	<script src="assets/js/components.js"></script>
   <script src="assets/js/jquery.min.js"></script>
   <script src="assets/js/jquery.scrolly.min.js"></script>
   <script src="assets/js/jquery.dropotron.min.js"></script>

--- a/CamlChess.html
+++ b/CamlChess.html
@@ -1,4 +1,4 @@
-<!DOCTYPE HTML>
+﻿<!DOCTYPE HTML>
 <html>
 
 <head>
@@ -16,35 +16,7 @@
   <div id="page-wrapper">
 
     <!-- Header -->
-    <header id="header">
-      <h1 id="logo"><a href="index.html" class="scrolly"><img src="Media/Website_Logo_No_BG.png" height="100%"></a></h1>
-      <nav id="nav">
-        <ul>
-          <li><a href="index.html#one" class="scrolly">About Me</a></li>
-          <li><a href="index.html#two" class="scrolly">Education</a></li>
-          <li>
-            <a href="index.html#three" class="scrolly">Experience ⌵</a>
-            <ul>
-              <li><a href="Coinbase.html" class="scrolly">Coinbase</a></li>
-              <li><a href="Amazon.html" class="scrolly">Amazon</a></li>
-              <li><a href="CU_GeoData.html" class="scrolly">CU GeoData</a></li>
-              <li><a href="Cornell_TA.html" class="scrolly">Cornell TA</a></li>
-            </ul>
-          </li>
-          <li>
-            <a href="index.html#four" class="scrolly">Projects ⌵</a>
-            <ul>
-              <li><a href="Tax_Lot_Split.html" class="scrolly">Tax Lot Split</a></li>
-              <li><a href="Bridge_Quote_Simulation.html" class="scrolly">Bridge Quote Simulation</a></li>
-              <li><a href="Anomaly_Detection.html" class="scrolly">Anomaly Detection</a></li>
-              <li><a href="#" class="scrolly">CamlChess</a></li>
-              <li><a href="https://github.com/NatanAklilu/SpaceInvaders" class="scrolly">Space Invaders</a></li>
-            </ul>
-          </li>
-          <li><a href="Media/Natan_Aklilu_Resume_2026.pdf" download class="button primary">Resume</a></li>
-        </ul>
-      </nav>
-    </header>
+    <site-nav data-page="camlchess"></site-nav>
 
     <!-- Adding a button to help bring user to top of page (using some Javascript)-->
 
@@ -143,30 +115,13 @@
       </video>
     </div>
 
-    <!-- Footer: More navigation linking to other sections-->
-    <footer id="footer">
-      <ul class="footer-links">
-        <li><a href="index.html#header" class="scrolly">Home</a></li>
-        <li><a href="index.html#one" class="scrolly">About</a></li>
-        <li><a href="index.html#three" class="scrolly">Experience</a></li>
-        <li><a href="index.html#four" class="scrolly">Projects</a></li>
-        <li><a href="https://www.linkedin.com/in/natantaklilu/" class="contact">Contact</a></li>
-      </ul>
-
-      <!-- Center: Logo Image -->
-      <div class="footer-logo">
-        <a href="index.html#banner" class="scrolly"><img src="Media/Website_Logo_No_BG.png" height="70em"></a>
-      </div>
-
-      <!-- Right: Copyright Information -->
-      <div class="footer-copyright">
-        &copy; 2026 Natan Aklilu. All rights reserved.
-      </div>
-    </footer>
+    <!-- Footer -->
+    <site-footer data-page="camlchess"></site-footer>
 
   </div>
 
   <!-- Scripts -->
+	<script src="assets/js/components.js"></script>
   <script src="assets/js/jquery.min.js"></script>
   <script src="assets/js/jquery.scrolly.min.js"></script>
   <script src="assets/js/jquery.dropotron.min.js"></script>

--- a/Coinbase.html
+++ b/Coinbase.html
@@ -1,4 +1,4 @@
-<!DOCTYPE HTML>
+﻿<!DOCTYPE HTML>
 <html>
 
 <head>
@@ -17,35 +17,7 @@
   <div id="page-wrapper">
 
     <!-- Header -->
-    <header id="header">
-      <h1 id="logo"><a href="index.html" class="scrolly"><img src="Media/Website_Logo_No_BG.png" height="100%"></a></h1>
-      <nav id="nav">
-        <ul>
-          <li><a href="index.html#one" class="scrolly">About Me</a></li>
-          <li><a href="index.html#two" class="scrolly">Education</a></li>
-          <li>
-            <a href="index.html#three" class="scrolly">Experience ⌵</a>
-            <ul>
-              <li><a href="#" class="scrolly">Coinbase</a></li>
-              <li><a href="Amazon.html" class="scrolly">Amazon</a></li>
-              <li><a href="CU_GeoData.html" class="scrolly">CU GeoData</a></li>
-              <li><a href="Cornell_TA.html" class="scrolly">Cornell TA</a></li>
-            </ul>
-          </li>
-          <li>
-            <a href="index.html#four" class="scrolly">Projects ⌵</a>
-            <ul>
-              <li><a href="Tax_Lot_Split.html" class="scrolly">Tax Lot Split</a></li>
-              <li><a href="Bridge_Quote_Simulation.html" class="scrolly">Bridge Quote Simulation</a></li>
-              <li><a href="Anomaly_Detection.html" class="scrolly">Anomaly Detection</a></li>
-              <li><a href="CamlChess.html" class="scrolly">CamlChess</a></li>
-              <li><a href="https://github.com/NatanAklilu/SpaceInvaders" class="scrolly">Space Invaders</a></li>
-            </ul>
-          </li>
-          <li><a href="Media/Natan_Aklilu_Resume_2026.pdf" download class="button primary">Resume</a></li>
-        </ul>
-      </nav>
-    </header>
+    <site-nav data-page="coinbase"></site-nav>
 
     <!-- Adding a button to help bring user to top of page (using some Javascript)-->
 
@@ -177,30 +149,13 @@
       </div>
     </div>
 
-    <!-- Footer: More navigation linking to other sections-->
-    <footer id="footer">
-      <ul class="footer-links">
-        <li><a href="index.html#header" class="scrolly">Home</a></li>
-        <li><a href="index.html#one" class="scrolly">About</a></li>
-        <li><a href="index.html#three" class="scrolly">Experience</a></li>
-        <li><a href="index.html#four" class="scrolly">Projects</a></li>
-        <li><a href="https://www.linkedin.com/in/natantaklilu/" class="contact">Contact</a></li>
-      </ul>
-
-      <!-- Center: Logo Image -->
-      <div class="footer-logo">
-        <a href="index.html#banner" class="scrolly"><img src="Media/Website_Logo_No_BG.png" height="70em"></a>
-      </div>
-
-      <!-- Right: Copyright Information -->
-      <div class="footer-copyright">
-        &copy; 2026 Natan Aklilu. All rights reserved.
-      </div>
-    </footer>
+    <!-- Footer -->
+    <site-footer data-page="coinbase"></site-footer>
 
   </div>
 
   <!-- Scripts -->
+	<script src="assets/js/components.js"></script>
   <script src="assets/js/jquery.min.js"></script>
   <script src="assets/js/jquery.scrolly.min.js"></script>
   <script src="assets/js/jquery.dropotron.min.js"></script>

--- a/Cornell_TA.html
+++ b/Cornell_TA.html
@@ -1,4 +1,4 @@
-<!DOCTYPE HTML>
+﻿<!DOCTYPE HTML>
 <html>
 
 <head>
@@ -17,35 +17,7 @@
   <div id="page-wrapper">
 
     <!-- Header -->
-    <header id="header">
-      <h1 id="logo"><a href="index.html" class="scrolly"><img src="Media/Website_Logo_No_BG.png" height="100%"></a></h1>
-      <nav id="nav">
-        <ul>
-          <li><a href="index.html#one" class="scrolly">About Me</a></li>
-          <li><a href="index.html#two" class="scrolly">Education</a></li>
-          <li>
-            <a href="index.html#three" class="scrolly">Experience ⌵</a>
-            <ul>
-              <li><a href="Coinbase.html" class="scrolly">Coinbase</a></li>
-              <li><a href="Amazon.html" class="scrolly">Amazon</a></li>
-              <li><a href="CU_GeoData.html" class="scrolly">CU GeoData</a></li>
-              <li><a href="#" class="scrolly">Cornell TA</a></li>
-            </ul>
-          </li>
-          <li>
-            <a href="index.html#four" class="scrolly">Projects ⌵</a>
-            <ul>
-              <li><a href="Tax_Lot_Split.html" class="scrolly">Tax Lot Split</a></li>
-              <li><a href="Bridge_Quote_Simulation.html" class="scrolly">Bridge Quote Simulation</a></li>
-              <li><a href="Anomaly_Detection.html" class="scrolly">Anomaly Detection</a></li>
-              <li><a href="CamlChess.html" class="scrolly">CamlChess</a></li>
-              <li><a href="https://github.com/NatanAklilu/SpaceInvaders" class="scrolly">Space Invaders</a></li>
-            </ul>
-          </li>
-          <li><a href="Media/Natan_Aklilu_Resume_2026.pdf" download class="button primary">Resume</a></li>
-        </ul>
-      </nav>
-    </header>
+    <site-nav data-page="cornell-ta"></site-nav>
 
     <!-- Adding a button to help bring user to top of page (using some Javascript)-->
 
@@ -167,30 +139,13 @@
       </div>
     </div>
 
-    <!-- Footer: More navigation linking to other sections-->
-    <footer id="footer">
-      <ul class="footer-links">
-        <li><a href="index.html#header" class="scrolly">Home</a></li>
-        <li><a href="index.html#one" class="scrolly">About</a></li>
-        <li><a href="index.html#three" class="scrolly">Experience</a></li>
-        <li><a href="index.html#four" class="scrolly">Projects</a></li>
-        <li><a href="https://www.linkedin.com/in/natantaklilu/" class="contact">Contact</a></li>
-      </ul>
-
-      <!-- Center: Logo Image -->
-      <div class="footer-logo">
-        <a href="index.html#banner" class="scrolly"><img src="Media/Website_Logo_No_BG.png" height="70em"></a>
-      </div>
-
-      <!-- Right: Copyright Information -->
-      <div class="footer-copyright">
-        &copy; 2026 Natan Aklilu. All rights reserved.
-      </div>
-    </footer>
+    <!-- Footer -->
+    <site-footer data-page="cornell-ta"></site-footer>
 
   </div>
 
   <!-- Scripts -->
+	<script src="assets/js/components.js"></script>
   <script src="assets/js/jquery.min.js"></script>
   <script src="assets/js/jquery.scrolly.min.js"></script>
   <script src="assets/js/jquery.dropotron.min.js"></script>

--- a/Tax_Lot_Split.html
+++ b/Tax_Lot_Split.html
@@ -1,4 +1,4 @@
-<!DOCTYPE HTML>
+﻿<!DOCTYPE HTML>
 <html>
 
 <head>
@@ -17,35 +17,7 @@
   <div id="page-wrapper">
 
     <!-- Header -->
-    <header id="header">
-      <h1 id="logo"><a href="index.html" class="scrolly"><img src="Media/Website_Logo_No_BG.png" height="100%"></a></h1>
-      <nav id="nav">
-        <ul>
-          <li><a href="index.html#one" class="scrolly">About Me</a></li>
-          <li><a href="index.html#two" class="scrolly">Education</a></li>
-          <li>
-            <a href="index.html#three" class="scrolly">Experience ⌵</a>
-            <ul>
-              <li><a href="Coinbase.html" class="scrolly">Coinbase</a></li>
-              <li><a href="Amazon.html" class="scrolly">Amazon</a></li>
-              <li><a href="CU_GeoData.html" class="scrolly">CU GeoData</a></li>
-              <li><a href="Cornell_TA.html" class="scrolly">Cornell TA</a></li>
-            </ul>
-          </li>
-          <li>
-            <a href="index.html#four" class="scrolly">Projects ⌵</a>
-            <ul>
-              <li><a href="#" class="scrolly">Tax Lot Split</a></li>
-              <li><a href="Bridge_Quote_Simulation.html" class="scrolly">Bridge Quote Simulation</a></li>
-              <li><a href="Anomaly_Detection.html" class="scrolly">Anomaly Detection</a></li>
-              <li><a href="CamlChess.html" class="scrolly">CamlChess</a></li>
-              <li><a href="https://github.com/NatanAklilu/SpaceInvaders" class="scrolly">Space Invaders</a></li>
-            </ul>
-          </li>
-          <li><a href="Media/Natan_Aklilu_Resume_2026.pdf" download class="button primary">Resume</a></li>
-        </ul>
-      </nav>
-    </header>
+    <site-nav data-page="tax-lot-split"></site-nav>
 
     <!-- Adding a button to help bring user to top of page (using some Javascript)-->
 
@@ -170,30 +142,13 @@
       </div>
     </div>
 
-    <!-- Footer: More navigation linking to other sections-->
-    <footer id="footer">
-      <ul class="footer-links">
-        <li><a href="index.html#header" class="scrolly">Home</a></li>
-        <li><a href="index.html#one" class="scrolly">About</a></li>
-        <li><a href="index.html#three" class="scrolly">Experience</a></li>
-        <li><a href="index.html#four" class="scrolly">Projects</a></li>
-        <li><a href="https://www.linkedin.com/in/natantaklilu/" class="contact">Contact</a></li>
-      </ul>
-
-      <!-- Center: Logo Image -->
-      <div class="footer-logo">
-        <a href="index.html#banner" class="scrolly"><img src="Media/Website_Logo_No_BG.png" height="70em"></a>
-      </div>
-
-      <!-- Right: Copyright Information -->
-      <div class="footer-copyright">
-        &copy; 2026 Natan Aklilu. All rights reserved.
-      </div>
-    </footer>
+    <!-- Footer -->
+    <site-footer data-page="tax-lot-split"></site-footer>
 
   </div>
 
   <!-- Scripts -->
+	<script src="assets/js/components.js"></script>
   <script src="assets/js/jquery.min.js"></script>
   <script src="assets/js/jquery.scrolly.min.js"></script>
   <script src="assets/js/jquery.dropotron.min.js"></script>

--- a/assets/js/components.js
+++ b/assets/js/components.js
@@ -32,13 +32,13 @@
               <li><a href="${p}#one" class="scrolly">About Me</a></li>
               <li><a href="${p}#two" class="scrolly">Education</a></li>
               <li>
-                <a href="${p}#three" class="scrolly">Experience &#8964;</a>
+                <a href="${p}#three" class="scrolly">Experience &#9013;</a>
                 <ul>
                   ${expLinks.map(li).join('\n                  ')}
                 </ul>
               </li>
               <li>
-                <a href="${p}#four" class="scrolly">Projects &#8964;</a>
+                <a href="${p}#four" class="scrolly">Projects &#9013;</a>
                 <ul>
                   ${projLinks.map(li).join('\n                  ')}
                 </ul>

--- a/assets/js/components.js
+++ b/assets/js/components.js
@@ -1,0 +1,83 @@
+(function () {
+
+  class SiteNav extends HTMLElement {
+    connectedCallback() {
+      const page = this.getAttribute('data-page') || 'index';
+      const isHome = page === 'index';
+      const p = isHome ? '' : 'index.html';
+
+      const expLinks = [
+        { key: 'coinbase',    href: 'Coinbase.html',              label: 'Coinbase' },
+        { key: 'amazon',      href: 'Amazon.html',                label: 'Amazon' },
+        { key: 'cu-geodata',  href: 'CU_GeoData.html',            label: 'CU GeoData' },
+        { key: 'cornell-ta',  href: 'Cornell_TA.html',            label: 'Cornell TA' },
+      ];
+
+      const projLinks = [
+        { key: 'tax-lot-split',    href: 'Tax_Lot_Split.html',            label: 'Tax Lot Split' },
+        { key: 'bridge-quote',     href: 'Bridge_Quote_Simulation.html',  label: 'Bridge Quote Simulation' },
+        { key: 'anomaly',          href: 'Anomaly_Detection.html',        label: 'Anomaly Detection' },
+        { key: 'camlchess',        href: 'CamlChess.html',                label: 'CamlChess' },
+        { key: 'space-invaders',   href: 'https://github.com/NatanAklilu/SpaceInvaders', label: 'Space Invaders' },
+      ];
+
+      const li = ({ key, href, label }) =>
+        `<li><a href="${key === page ? '#' : href}" class="scrolly">${label}</a></li>`;
+
+      this.innerHTML = `
+        <header id="header">
+          <h1 id="logo"><a href="index.html" class="scrolly"><img src="Media/Website_Logo_No_BG.png" height="100%"></a></h1>
+          <nav id="nav">
+            <ul>
+              <li><a href="${p}#one" class="scrolly">About Me</a></li>
+              <li><a href="${p}#two" class="scrolly">Education</a></li>
+              <li>
+                <a href="${p}#three" class="scrolly">Experience &#8964;</a>
+                <ul>
+                  ${expLinks.map(li).join('\n                  ')}
+                </ul>
+              </li>
+              <li>
+                <a href="${p}#four" class="scrolly">Projects &#8964;</a>
+                <ul>
+                  ${projLinks.map(li).join('\n                  ')}
+                </ul>
+              </li>
+              <li><a href="Media/Natan_Aklilu_Resume_2026.pdf" download class="button primary">Resume</a></li>
+            </ul>
+          </nav>
+        </header>`;
+    }
+  }
+
+  class SiteFooter extends HTMLElement {
+    connectedCallback() {
+      const page = this.getAttribute('data-page') || 'index';
+      const isHome = page === 'index';
+      const p = isHome ? '' : 'index.html';
+
+      this.innerHTML = `
+        <footer id="footer">
+          <ul class="footer-links">
+            <li><a href="${p}#header" class="scrolly">Home</a></li>
+            <li><a href="${p}#one" class="scrolly">About</a></li>
+            <li><a href="${p}#three" class="scrolly">Experience</a></li>
+            <li><a href="${p}#four" class="scrolly">Projects</a></li>
+            <li><a href="https://www.linkedin.com/in/natantaklilu/" class="contact">Contact</a></li>
+          </ul>
+          <div class="footer-logo">
+            <a href="${isHome ? '#banner' : 'index.html#banner'}" class="scrolly">
+              <img src="Media/Website_Logo_No_BG.png" height="70em">
+            </a>
+          </div>
+          <div class="footer-copyright">
+            &copy; 2026 Natan Aklilu. All rights reserved.
+          </div>
+        </footer>`;
+    }
+  }
+
+  customElements.define('site-nav', SiteNav);
+  customElements.define('site-footer', SiteFooter);
+
+})();

--- a/index.html
+++ b/index.html
@@ -1,4 +1,4 @@
-<!DOCTYPE HTML>
+﻿<!DOCTYPE HTML>
 <html>
 
 <head>
@@ -16,35 +16,7 @@
 	<div id="page-wrapper">
 
 		<!-- Header -->
-		<header id="header">
-			<h1 id="logo"><a href="index.html" class="scrolly"><img src="Media/Website_Logo_No_BG.png" height="100%"></a></h1>
-			<nav id="nav">
-				<ul>
-					<li><a href="#one" class="scrolly">About Me</a></li>
-					<li><a href="#two" class="scrolly">Education</a></li>
-					<li>
-						<a href="#three" class="scrolly">Experience ⌵</a>
-						<ul>
-							<li><a href="Coinbase.html" class="scrolly">Coinbase</a></li>
-							<li><a href="Amazon.html" class="scrolly">Amazon</a></li>
-							<li><a href="CU_GeoData.html" class="scrolly">CU GeoData</a></li>
-							<li><a href="Cornell_TA.html" class="scrolly">Cornell TA</a></li>
-						</ul>
-					</li>
-					<li>
-						<a href="#four" class="scrolly">Projects ⌵</a>
-						<ul>
-							<li><a href="Tax_Lot_Split.html" class="scrolly">Tax Lot Split</a></li>
-							<li><a href="Bridge_Quote_Simulation.html" class="scrolly">Bridge Quote Simulation</a></li>
-							<li><a href="Anomaly_Detection.html" class="scrolly">Anomaly Detection</a></li>
-							<li><a href="CamlChess.html" class="scrolly">CamlChess</a></li>
-							<li><a href="https://github.com/NatanAklilu/SpaceInvaders" class="scrolly">Space Invaders</a></li>
-						</ul>
-					</li>
-					<li><a href="Media/Natan_Aklilu_Resume_2026.pdf" download class="button primary">Resume</a></li>
-				</ul>
-			</nav>
-		</header>
+		<site-nav data-page="index"></site-nav>
 
 		<!-- Banner: Home -->
 		<section id="banner">
@@ -315,31 +287,13 @@
 			</section>
 		</section>
 
-		<!-- Footer: More navigation linking to other sections-->
-		<footer id="footer">
-			<ul class="footer-links">
-				<li><a href="#header" class="scrolly">Home</a></li>
-				<li><a href="#one" class="scrolly">About</a></li>
-				<li><a href="#three" class="scrolly">Experience</a></li>
-				<li><a href="#four" class="scrolly">Projects</a></li>
-				<!-- Add animation of LinkedIn logo popping out when hovering -->
-				<li><a href="https://www.linkedin.com/in/natantaklilu/" class="contact">Contact</a></li>
-			</ul>
-
-			<!-- Center: Logo Image -->
-			<div class="footer-logo">
-				<a href="#banner" class="scrolly"><img src="Media/Website_Logo_No_BG.png" height="70em"></a>
-			</div>
-
-			<!-- Right: Copyright Information -->
-			<div class="footer-copyright">
-				&copy; 2026 Natan Aklilu. All rights reserved.
-			</div>
-		</footer>
+		<!-- Footer -->
+		<site-footer data-page="index"></site-footer>
 
 	</div>
 
 	<!-- Scripts -->
+	<script src="assets/js/components.js"></script>
 	<script src="assets/js/jquery.min.js"></script>
 	<script src="assets/js/jquery.scrolly.min.js"></script>
 	<script src="assets/js/jquery.dropotron.min.js"></script>


### PR DESCRIPTION
﻿## What Changed?
- Created assets/js/components.js with two native Web Components: site-nav and site-footer
- Replaced the copy-pasted header block on all 9 pages with a single site-nav tag
- Replaced the copy-pasted footer block on all 9 pages with a single site-footer tag
- Added components.js script include to all 9 pages

## Why
The nav and footer were duplicated across 9 HTML files, meaning any change required editing every page individually. Now a single edit to components.js instantly updates all pages. This also eliminates the risk of pages going out of sync.

## How It Works
Each page passes its identity via a data-page attribute:
  site-nav data-page="amazon"
  site-footer data-page="amazon"

The component uses this to set hash-only vs index.html-prefixed links (home vs sub-pages) and to mark the current page as active in the nav dropdown (href="#").

## Files Changed
- assets/js/components.js (new) - Web Component definitions for site-nav and site-footer
- index.html, Amazon.html, Coinbase.html, Cornell_TA.html, CU_GeoData.html, Tax_Lot_Split.html, Bridge_Quote_Simulation.html, Anomaly_Detection.html, CamlChess.html - header/footer replaced with custom elements

## Testing
- [x] Open each page locally and verify the nav renders correctly with all dropdowns
- [x] Verify the active page in the nav dropdown shows href="#" (no self-link)
- [x] Verify footer links work correctly on both home page and sub-pages
- [x] Confirm jQuery nav dropdown (dropotron) still functions correctly
- [x] Confirm smooth scroll (scrolly) still works on home page nav links

## Linear
Closes [NAT-23](https://linear.app/natan-personal/issue/NAT-23/componentize-header-and-footer-using-web-components)
