### PR TITLE
feat(NAT-25): add project page links to experience pages

### DIFF
--- a/CU_GeoData.html
+++ b/CU_GeoData.html
@@ -107,6 +107,9 @@
                   the problems we are solving was invaluable and taught me to value the impact I make on the community.
                 </li>
               </ul>
+              <ul class="actions" style="display: flex; justify-content: center;">
+                <li><a href="https://www.cugeodata.com/data-team" class="button">CU GeoData Website</a></li>
+              </ul>
               <br>
             </section>
 

--- a/Coinbase.html
+++ b/Coinbase.html
@@ -125,6 +125,9 @@
                   engineers, product managers, and stakeholders across the organization sharpened
                   my ability to build alignment and deliver in a complex, fast-moving environment.</li>
               </ul>
+              <ul class="actions" style="display: flex; justify-content: center;">
+                <li><a href="Tax_Lot_Split.html" class="button">View Project: Tax Lot Split &amp; Selection APIs</a></li>
+              </ul>
               <br>
             </section>
 


### PR DESCRIPTION
﻿## What Changed?
- Added "View Project: Tax Lot Split & Selection APIs" button to the bottom of Coinbase.html content section, linking to Tax_Lot_Split.html
- Added "CU GeoData Website" button to the bottom of CU_GeoData.html content section, linking to the external CU GeoData data team page
- Amazon.html already had a "View Project: Anomaly Detection" button - no change needed

## Why
Experience pages were standalone with no path to related project pages. Visitors can now flow naturally from a role to the specific deliverable that came out of it, without hunting through the nav.

## Files Changed
- Coinbase.html - added project link button after Takeaways section
- CU_GeoData.html - added external website link button after Takeaways section

## Testing
- [ ] Open Coinbase.html and verify the Tax Lot Split button appears below Takeaways and navigates correctly
- [ ] Open CU_GeoData.html and verify the CU GeoData Website button appears and opens the correct external link
- [ ] Confirm button styling is consistent with the existing Anomaly Detection button on Amazon.html

## Linear
Closes [NAT-25](https://linear.app/natan-personal/issue/NAT-25/add-project-page-links-to-relevant-experience-pages)
