### PR TITLE
chore(NAT-27): remove duplicate photo galleries from project pages

### DIFF
--- a/Anomaly_Detection.html
+++ b/Anomaly_Detection.html
@@ -7,7 +7,6 @@
   <meta charset="utf-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1, user-scalable=no" />
   <link rel="stylesheet" href="assets/css/main.css" />
-  <link rel="stylesheet" href="assets/css/flickity.css">
   <noscript>
     <link rel="stylesheet" href="assets/css/noscript.css" />
   </noscript>
@@ -123,28 +122,6 @@
       </div>
     </div>
 
-    <h2 style="text-align: center;">Amazon Intern Experience Gallery</h2>
-
-    <!-- Gallery Slideshow -->
-
-    <div class="carousel js-flickity" data-flickity-options='{ "wrapAround": true }'>
-      <div class="carousel-cell">
-        <img src="Media/Amazon_Bonding_Event.jpg" alt="" />
-      </div>
-      <div class="carousel-cell">
-        <img src="Media/Amazon_Merch.jpg" alt="" />
-      </div>
-      <div class="carousel-cell">
-        <img src="Media/Amazon_In_Person.jpg" alt="" />
-      </div>
-      <div class="carousel-cell">
-        <img src="Media/Amazon_Desk.jpg" alt="" />
-      </div>
-      <div class="carousel-cell">
-        <img src="Media/Amazon_WFH.jpg" alt="" />
-      </div>
-    </div>
-
     <!-- Footer -->
     <site-footer data-page="anomaly"></site-footer>
 
@@ -160,7 +137,6 @@
   <script src="assets/js/breakpoints.min.js"></script>
   <script src="assets/js/util.js"></script>
   <script src="assets/js/main.js"></script>
-  <script src="assets/js/flickity.pkgd.js"></script>
 
 </body>
 

--- a/Bridge_Quote_Simulation.html
+++ b/Bridge_Quote_Simulation.html
@@ -7,7 +7,6 @@
   <meta charset="utf-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1, user-scalable=no" />
   <link rel="stylesheet" href="assets/css/main.css" />
-  <link rel="stylesheet" href="assets/css/flickity.css">
   <noscript>
     <link rel="stylesheet" href="assets/css/noscript.css" />
   </noscript>
@@ -135,34 +134,6 @@
       </div>
     </div>
 
-    <h2 style="text-align: center;">Coinbase Intern Experience Gallery</h2>
-
-    <!-- Gallery Slideshow -->
-
-    <div class="carousel js-flickity" data-flickity-options='{ "wrapAround": true }' style="padding: 0px;">
-      <div class="carousel-cell">
-        <img src="Media/Coinbase_Group_Pic.jpg" alt="" />
-      </div>
-      <div class="carousel-cell">
-        <img src="Media/Coinbase_Intern_Event.jpg" alt="" />
-      </div>
-      <div class="carousel-cell">
-        <img src="Media/Coinbase_Cryptern_Event.jpg" alt="" />
-      </div>
-      <div class="carousel-cell">
-        <img src="Media/Coinbase_Manager_Mentor_Farewell.jpg" alt="" />
-      </div>
-      <div class="carousel-cell">
-        <img src="Media/Coinbase_Office.jpg" alt="" />
-      </div>
-      <div class="carousel-cell">
-        <img src="Media/Coinbase_SF_Office.jpg" alt="" />
-      </div>
-      <div class="carousel-cell">
-        <img src="Media/Coinbase_Interns_Pic.jpg" alt="" />
-      </div>
-    </div>
-
     <!-- Footer -->
     <site-footer data-page="bridge-quote"></site-footer>
 
@@ -178,7 +149,6 @@
   <script src="assets/js/breakpoints.min.js"></script>
   <script src="assets/js/util.js"></script>
   <script src="assets/js/main.js"></script>
-  <script src="assets/js/flickity.pkgd.js"></script>
 
 </body>
 

--- a/Tax_Lot_Split.html
+++ b/Tax_Lot_Split.html
@@ -7,7 +7,6 @@
   <meta charset="utf-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1, user-scalable=no" />
   <link rel="stylesheet" href="assets/css/main.css" />
-  <link rel="stylesheet" href="assets/css/flickity.css">
   <noscript>
     <link rel="stylesheet" href="assets/css/noscript.css" />
   </noscript>
@@ -129,22 +128,6 @@
       </div>
     </div>
 
-    <h2 style="text-align: center;">Coinbase Experience Gallery</h2>
-
-    <!-- Gallery Slideshow -->
-
-    <div class="carousel js-flickity" data-flickity-options='{ "wrapAround": true }' style="padding: 0px;">
-      <div class="carousel-cell">
-        <img src="Media/Coinbase_Group_Pic_Resized.jpg" alt="" />
-      </div>
-      <div class="carousel-cell">
-        <img src="Media/Coinbase_Office.jpg" alt="" />
-      </div>
-      <div class="carousel-cell">
-        <img src="Media/Coinbase_SF_Office.jpg" alt="" />
-      </div>
-    </div>
-
     <!-- Footer -->
     <site-footer data-page="tax-lot-split"></site-footer>
 
@@ -160,7 +143,6 @@
   <script src="assets/js/breakpoints.min.js"></script>
   <script src="assets/js/util.js"></script>
   <script src="assets/js/main.js"></script>
-  <script src="assets/js/flickity.pkgd.js"></script>
 
 </body>
 


### PR DESCRIPTION
﻿## What Changed?
- Removed the photo gallery carousel from Tax_Lot_Split.html (Coinbase Experience Gallery)
- Removed the photo gallery carousel from Bridge_Quote_Simulation.html (Coinbase Intern Experience Gallery)
- Removed the photo gallery carousel from Anomaly_Detection.html (Amazon Intern Experience Gallery)
- Removed unused lickity.css stylesheet link and lickity.pkgd.js script tag from all three pages

## Why
The same photo galleries already exist on the corresponding Experience pages (Coinbase.html and Amazon.html). Duplicating them on project pages was redundant and diluted the focus of the project write-ups. Galleries belong with the experience context, not the project detail.

## Files Changed
- Tax_Lot_Split.html
- Bridge_Quote_Simulation.html
- Anomaly_Detection.html

## Testing
- [x] Visit Tax_Lot_Split.html - no gallery visible, footer renders correctly
- [x] Visit Bridge_Quote_Simulation.html - no gallery visible, footer renders correctly
- [x] Visit Anomaly_Detection.html - no gallery visible, footer renders correctly
- [x] Confirm galleries still present on Coinbase.html and Amazon.html

## Linear
Closes [NAT-27](https://linear.app/natan-personal/issue/NAT-27)
