### PR TITLE
fix(NAT-28): wrap CamlChess gameplay section in page container

### DIFF
--- a/CamlChess.html
+++ b/CamlChess.html
@@ -102,17 +102,19 @@
       </div>
     </div>
 
-    <h2 style="text-align: center;">Command Line Chess Gameplay</h2>
-    <div style="text-align: center; padding-bottom: 2em;">
-      <p style="text-align: center;">
-        Here is a video of a full chess game. Note that this is played in local mode, 
-        but you can choose to play against the AI opponent during initial game setup! 
-        All code can be found in the GitHub repository <a href="https://github.com/NatanAklilu/CamlChess">here</a>!
-        Watch as the chess board and move history update with each move:
-      </p>
-      <video width="60%" height="60%" controls muted>
-        <source src="Media/Full_Chess_Match_Example.mp4" type="video/mp4">
-      </video>
+    <div class="wrapper style1">
+      <div class="container" style="padding-bottom: 2em; text-align: center;">
+        <h2>Command Line Chess Gameplay</h2>
+        <p>
+          Here is a video of a full chess game. Note that this is played in local mode,
+          but you can choose to play against the AI opponent during initial game setup!
+          All code can be found in the GitHub repository <a href="https://github.com/NatanAklilu/CamlChess">here</a>!
+          Watch as the chess board and move history update with each move:
+        </p>
+        <video width="60%" height="60%" controls muted>
+          <source src="Media/Full_Chess_Match_Example.mp4" type="video/mp4">
+        </video>
+      </div>
     </div>
 
     <!-- Footer -->


### PR DESCRIPTION
﻿## What Changed?
- Wrapped the "Command Line Chess Gameplay" section in the standard wrapper style1 + container divs

## Why
The section was sitting outside the page's layout containers, so the heading and paragraph text stretched edge-to-edge with no side margins, hitting both viewport boundaries. Wrapping it in the same container used everywhere else brings it in line with the rest of the page.

## Files Changed
- CamlChess.html

## Testing
- [x] Visit CamlChess.html and scroll to the gameplay section - text and video should be centered with consistent side margins matching the rest of the page

## Linear
Closes [NAT-28](https://linear.app/natan-personal/issue/NAT-28)
