### PR TITLE
feat(NAT-19): add entrance animations, typewriter, and stat counters to banner

### DIFF
--- a/assets/css/main.css
+++ b/assets/css/main.css
@@ -2305,38 +2305,93 @@ header.major:after {
 
 .typed-out {
 	overflow: hidden;
-	border-right: .1em solid;
 	white-space: nowrap;
-	font-size: 1.6rem;
-	width: 0;
-	animation:
-		typing 5s steps(20, end) forwards infinite,
-		blink 1s infinite;
+	display: inline-block;
+	width: auto;
+	border-right: 0.1em solid transparent;
+}
+
+.typed-out.typing-done {
+	border-right: 0.1em solid rgba(255, 255, 255, 0.75);
+	animation: blinking-cursor 0.75s step-end infinite;
+}
+
+/* ===== Banner Entrance Animations ===== */
+
+@keyframes bannerFadeSlideUp {
+	from { opacity: 0; transform: translateY(16px); }
+	to   { opacity: 1; transform: translateY(0); }
+}
+
+@keyframes blinking-cursor {
+	from, to { border-color: transparent; }
+	50%       { border-color: rgba(255, 255, 255, 0.75); }
+}
+
+#banner .content header h2 {
+	opacity: 0;
+	animation: bannerFadeSlideUp 0.7s ease both 0.2s;
+}
+
+#banner .content .typed-out {
+	opacity: 0;
+	animation: bannerFadeSlideUp 0.5s ease both 0.85s;
+}
+
+#banner .content .icons {
+	opacity: 0;
+	animation: bannerFadeSlideUp 0.5s ease both 1.5s;
+}
+
+.banner-stats {
+	display: flex;
+	justify-content: center;
+	gap: 3em;
+	margin-top: 1.75em;
+	opacity: 0;
+	animation: bannerFadeSlideUp 0.5s ease both 2.0s;
+}
+
+.banner-stats .stat {
+	text-align: center;
+}
+
+.banner-stats .stat-num {
+	display: block;
+	font-size: 2.2em;
+	font-weight: 700;
+	color: #ffffff;
+	line-height: 1;
+}
+
+.banner-stats .stat-label {
+	display: block;
+	font-size: 0.65em;
+	text-transform: uppercase;
+	letter-spacing: 0.12em;
+	color: rgba(255, 255, 255, 0.55);
+	margin-top: 0.5em;
+}
+
+@media (prefers-reduced-motion: reduce) {
+	#banner .content header h2,
+	#banner .content .typed-out,
+	#banner .content .icons,
+	.banner-stats {
+		opacity: 1;
+		animation: none;
+	}
 }
 
 @keyframes typing {
-	0% {
-		width: 0
-	}
-
-	25% {
-		width: 50%
-	}
-
-	50%,
-	100% {
-		width: 100%
-	}
+	0% { width: 0 }
+	25% { width: 50% }
+	50%, 100% { width: 100% }
 }
 
 @keyframes blink {
-	from {
-		border-color: transparent
-	}
-
-	to {
-		border-color: #ff5722;
-	}
+	from { border-color: transparent }
+	to   { border-color: #ff5722; }
 }
 
 footer.major {
@@ -4407,6 +4462,10 @@ body.is-touch #banner {
 
 	#banner .content .image {
 		margin: 0;
+	}
+
+	.banner-stats {
+		gap: 2em;
 	}
 
 	/* Footer */

--- a/index.html
+++ b/index.html
@@ -23,8 +23,7 @@
 			<div class="content">
 				<header>
 					<h2 style="text-align:center; font-size:4em;">Natan Aklilu</h2>
-					<p class="typed-out" style="text-align:center; font-size:2em;">Software Engineer <span
-							style="font-size:1.3em; font-weight: 300;">|</span> Cornell CS '25</p>
+					<p class="typed-out" style="text-align:center; font-size:2em;"></p>
 					<ul class="icons">
 						<li style="font-size:1.5em">
 							<span class="icon-wrapper">
@@ -41,11 +40,72 @@
 							</span>
 						</li>
 					</ul>
+					<div class="banner-stats">
+						<div class="stat">
+							<span class="stat-num" data-target="3">0</span>
+							<span class="stat-label">Experiences</span>
+						</div>
+						<div class="stat">
+							<span class="stat-num" data-target="4">0</span>
+							<span class="stat-label">Projects</span>
+						</div>
+						<div class="stat">
+							<span class="stat-num" data-target="300" data-suffix="+">0</span>
+							<span class="stat-label">Students Taught</span>
+						</div>
+					</div>
 				</header>
 				<span class="image"><img src="Media/Natan_Aklilu_Headshot_Square.jpg" alt="" /></span>
 			</div>
 			<a href="#one" class="goto-next scrolly">Next</a>
 		</section>
+
+		<script>
+		(function () {
+			var reducedMotion = window.matchMedia('(prefers-reduced-motion: reduce)').matches;
+			var typedEl = document.querySelector('.typed-out');
+			var fullText = "Software Engineer  |  Cornell CS '25";
+
+			if (reducedMotion) {
+				typedEl.textContent = fullText;
+				document.querySelectorAll('.stat-num').forEach(function (el) {
+					el.textContent = el.dataset.target + (el.dataset.suffix || '');
+				});
+				return;
+			}
+
+			// Typewriter — starts after subtitle fades in (~950ms)
+			setTimeout(function () {
+				var i = 0;
+				function type() {
+					if (i < fullText.length) {
+						typedEl.textContent += fullText[i++];
+						setTimeout(type, 55);
+					} else {
+						typedEl.classList.add('typing-done');
+					}
+				}
+				type();
+			}, 950);
+
+			// Stat counters — start after stats section fades in (~2200ms)
+			setTimeout(function () {
+				document.querySelectorAll('.stat-num').forEach(function (el) {
+					var target = parseInt(el.dataset.target);
+					var suffix = el.dataset.suffix || '';
+					var duration = 1400;
+					var startTime = performance.now();
+					function update(now) {
+						var elapsed = Math.min(now - startTime, duration);
+						var progress = 1 - Math.pow(1 - elapsed / duration, 3);
+						el.textContent = Math.round(progress * target) + suffix;
+						if (elapsed < duration) requestAnimationFrame(update);
+					}
+					requestAnimationFrame(update);
+				});
+			}, 2200);
+		})();
+		</script>
 
 		<!-- Adding a button to help bring user to top of page (using some Javascript)-->
 


### PR DESCRIPTION
﻿## What Changed?
- Wired up the existing 	yped-out class with a JS character-by-character typewriter effect for the subtitle
- Added staggered fade + slide-up entrance animations for banner name, subtitle, icons, and stats (sequenced with CSS delays)
- Added animated stat counters that count up from 0: 3 Experiences, 4 Projects, 300+ Students Taught
- Replaced the broken CSS 	yping/link keyframes (width-percentage hack) with a clean JS-driven typewriter + blinking cursor class
- Added prefers-reduced-motion support — all animations and counters skip instantly for users who prefer it
- Added mobile responsive gap reduction for stats section

## Why
The banner was static and didn't make a strong first impression. The 	yped-out CSS class existed but was never properly animated. Adding sequential entrance animations, a typewriter, and stat counters creates a polished, dynamic hook that draws visitors in. Note: parallax was already present via ackground-attachment: fixed.

## Files Changed
- index.html — updated banner HTML (empty typed-out for JS, added stats div, added inline animation script)
- ssets/css/main.css — replaced broken typed-out CSS, added banner animation keyframes and stat styles

## Testing
- [ ] Load homepage — name fades+slides up first, then subtitle types out, then icons appear, then stats count up
- [ ] After typing completes the cursor blinks on the subtitle
- [ ] Stat counters animate smoothly to 3, 4, and 300+
- [ ] On mobile, stats display with reduced gap and remain readable
- [ ] Enable prefers-reduced-motion in OS settings — all text shows instantly, no animations

## Linear
Closes [NAT-19](https://linear.app/natan-personal/issue/NAT-19)
