### PR TITLE
feat(NAT-29): add cursor trail effect to homepage banner

### DIFF
--- a/assets/css/main.css
+++ b/assets/css/main.css
@@ -4121,20 +4121,19 @@ body.landing #header {
 }
 
 .cursor-trail-img-item {
-	padding: 6px;
+	padding: 0;
 	border-radius: 10px;
-	width: 68px;
-	height: 60px;
-	display: inline-flex;
-	align-items: center;
-	justify-content: center;
-	background: rgba(255, 255, 255, 0.95);
+	background: none;
+	border: 1px solid rgba(255, 255, 255, 0.25);
+	overflow: hidden;
+	width: auto;
+	height: auto;
 }
 
 .cursor-trail-img {
-	width: 54px;
-	height: 46px;
-	object-fit: contain;
+	width: 72px;
+	height: 54px;
+	display: block;
 	border-radius: 0;
 }
 

--- a/assets/css/main.css
+++ b/assets/css/main.css
@@ -4102,6 +4102,47 @@ body.landing #header {
 	z-index: 21;
 }
 
+/* Cursor trail badges */
+.cursor-trail-item {
+	position: absolute;
+	pointer-events: none;
+	user-select: none;
+	font-size: 0.72em;
+	font-weight: 600;
+	color: rgba(255, 255, 255, 0.92);
+	background: rgba(255, 255, 255, 0.08);
+	border: 1px solid rgba(255, 255, 255, 0.28);
+	padding: 4px 11px;
+	border-radius: 20px;
+	white-space: nowrap;
+	z-index: 30;
+	transform: translate(-50%, -50%);
+	animation: trailFadeOut 1.1s ease-out forwards;
+}
+
+.cursor-trail-img-item {
+	padding: 4px;
+	border-radius: 50%;
+	width: 46px;
+	height: 46px;
+	display: inline-flex;
+	align-items: center;
+	justify-content: center;
+	background: rgba(255, 255, 255, 0.95);
+}
+
+.cursor-trail-img {
+	width: 32px;
+	height: 32px;
+	object-fit: contain;
+	border-radius: 4px;
+}
+
+@keyframes trailFadeOut {
+	0%   { opacity: 0.9;  transform: translate(-50%, -50%) translateY(0px); }
+	100% { opacity: 0;    transform: translate(-50%, -50%) translateY(-52px); }
+}
+
 #banner:before {
 	content: '';
 	display: inline-block;

--- a/assets/css/main.css
+++ b/assets/css/main.css
@@ -4121,10 +4121,10 @@ body.landing #header {
 }
 
 .cursor-trail-img-item {
-	padding: 5px;
-	border-radius: 50%;
+	padding: 6px;
+	border-radius: 10px;
 	width: 68px;
-	height: 68px;
+	height: 60px;
 	display: inline-flex;
 	align-items: center;
 	justify-content: center;
@@ -4132,10 +4132,10 @@ body.landing #header {
 }
 
 .cursor-trail-img {
-	width: 50px;
-	height: 50px;
+	width: 54px;
+	height: 46px;
 	object-fit: contain;
-	border-radius: 4px;
+	border-radius: 0;
 }
 
 @keyframes trailFadeOut {

--- a/assets/css/main.css
+++ b/assets/css/main.css
@@ -4107,13 +4107,13 @@ body.landing #header {
 	position: absolute;
 	pointer-events: none;
 	user-select: none;
-	font-size: 0.72em;
+	font-size: 0.95em;
 	font-weight: 600;
-	color: rgba(255, 255, 255, 0.92);
-	background: rgba(255, 255, 255, 0.08);
-	border: 1px solid rgba(255, 255, 255, 0.28);
-	padding: 4px 11px;
-	border-radius: 20px;
+	color: rgba(255, 255, 255, 0.95);
+	background: rgba(255, 255, 255, 0.1);
+	border: 1px solid rgba(255, 255, 255, 0.3);
+	padding: 7px 16px;
+	border-radius: 24px;
 	white-space: nowrap;
 	z-index: 30;
 	transform: translate(-50%, -50%);
@@ -4121,10 +4121,10 @@ body.landing #header {
 }
 
 .cursor-trail-img-item {
-	padding: 4px;
+	padding: 5px;
 	border-radius: 50%;
-	width: 46px;
-	height: 46px;
+	width: 68px;
+	height: 68px;
 	display: inline-flex;
 	align-items: center;
 	justify-content: center;
@@ -4132,8 +4132,8 @@ body.landing #header {
 }
 
 .cursor-trail-img {
-	width: 32px;
-	height: 32px;
+	width: 50px;
+	height: 50px;
 	object-fit: contain;
 	border-radius: 4px;
 }

--- a/assets/css/main.css
+++ b/assets/css/main.css
@@ -4135,6 +4135,7 @@ body.landing #header {
 	height: 80px;
 	display: block;
 	border-radius: 0;
+	object-fit: cover;
 }
 
 @keyframes trailFadeOut {

--- a/assets/css/main.css
+++ b/assets/css/main.css
@@ -4131,8 +4131,8 @@ body.landing #header {
 }
 
 .cursor-trail-img {
-	width: 72px;
-	height: 54px;
+	width: 110px;
+	height: 80px;
 	display: block;
 	border-radius: 0;
 }

--- a/index.html
+++ b/index.html
@@ -72,16 +72,15 @@
 				{ type: 'text', content: 'Production Systems' },
 				{ type: 'text', content: 'Snowflake' },
 				{ type: 'text', content: 'Spark' },
-				{ type: 'img', src: 'Media/AWS_Logo.png',                    fit: 'contain' },
-				{ type: 'img', src: 'Media/Coinbase_Logo.jpg',               fit: 'contain' },
-				{ type: 'img', src: 'Media/Cornell_University_Logo.png',     fit: 'contain' },
-				{ type: 'img', src: 'Media/CU_GeoData_Logo.jpg',             fit: 'contain' },
-				{ type: 'img', src: 'Media/Coinbase_Group_Pic.jpg',          fit: 'cover' },
-				{ type: 'img', src: 'Media/Coinbase_Crypto_Stock_Pic.jpg',   fit: 'cover' },
-				{ type: 'img', src: 'Media/Coinbase_Office.jpg',             fit: 'cover' },
-				{ type: 'img', src: 'Media/Amazon_Bonding_Event.jpg',        fit: 'cover' },
-				{ type: 'img', src: 'Media/Amazon_In_Person.jpg',            fit: 'cover' },
-				{ type: 'img', src: 'Media/CU_GeoData_Data_Team_Pic.jpg',    fit: 'cover' }
+				{ type: 'img', src: 'Media/AWS_Logo.png' },
+				{ type: 'img', src: 'Media/Coinbase_Logo.jpg' },
+				{ type: 'img', src: 'Media/Cornell_University_Logo.png' },
+				{ type: 'img', src: 'Media/CU_GeoData_Logo.jpg' },
+				{ type: 'img', src: 'Media/Coinbase_Group_Pic.jpg' },
+				{ type: 'img', src: 'Media/Coinbase_Crypto_Stock_Pic.jpg' },
+				{ type: 'img', src: 'Media/Coinbase_Office.jpg' },
+				{ type: 'img', src: 'Media/Amazon_Bonding_Event.jpg' },
+				{ type: 'img', src: 'Media/CU_GeoData_Data_Team_Pic.jpg' }
 			];
 			var lastX = -999, lastY = -999, minDist = 70;
 
@@ -100,7 +99,6 @@
 					var img = document.createElement('img');
 					img.src = item.src;
 					img.className = 'cursor-trail-img';
-					img.style.objectFit = item.fit;
 					el.appendChild(img);
 				} else {
 					el.className = 'cursor-trail-item';

--- a/index.html
+++ b/index.html
@@ -72,10 +72,16 @@
 				{ type: 'text', content: 'Production Systems' },
 				{ type: 'text', content: 'Snowflake' },
 				{ type: 'text', content: 'Spark' },
-				{ type: 'img', src: 'Media/AWS_Logo.png',              alt: 'AWS' },
-				{ type: 'img', src: 'Media/Coinbase_Logo_3.jpg',       alt: 'Coinbase' },
-				{ type: 'img', src: 'Media/Cornell_University_Logo.png', alt: 'Cornell' },
-				{ type: 'img', src: 'Media/CU_GeoData_Logo_2.jpg',     alt: 'GeoData' }
+				{ type: 'img', src: 'Media/AWS_Logo.png',                    fit: 'contain' },
+				{ type: 'img', src: 'Media/Coinbase_Logo.jpg',               fit: 'contain' },
+				{ type: 'img', src: 'Media/Cornell_University_Logo.png',     fit: 'contain' },
+				{ type: 'img', src: 'Media/CU_GeoData_Logo.jpg',             fit: 'contain' },
+				{ type: 'img', src: 'Media/Coinbase_Group_Pic.jpg',          fit: 'cover' },
+				{ type: 'img', src: 'Media/Coinbase_Crypto_Stock_Pic.jpg',   fit: 'cover' },
+				{ type: 'img', src: 'Media/Coinbase_Office.jpg',             fit: 'cover' },
+				{ type: 'img', src: 'Media/Amazon_Bonding_Event.jpg',        fit: 'cover' },
+				{ type: 'img', src: 'Media/Amazon_In_Person.jpg',            fit: 'cover' },
+				{ type: 'img', src: 'Media/CU_GeoData_Data_Team_Pic.jpg',    fit: 'cover' }
 			];
 			var lastX = -999, lastY = -999, minDist = 70;
 
@@ -93,8 +99,8 @@
 					el.className = 'cursor-trail-item cursor-trail-img-item';
 					var img = document.createElement('img');
 					img.src = item.src;
-					img.alt = item.alt;
 					img.className = 'cursor-trail-img';
+					img.style.objectFit = item.fit;
 					el.appendChild(img);
 				} else {
 					el.className = 'cursor-trail-item';

--- a/index.html
+++ b/index.html
@@ -47,6 +47,68 @@
 			<a href="#one" class="goto-next scrolly">Next</a>
 		</section>
 
+		<script>
+		(function () {
+			if (!window.matchMedia('(hover: hover)').matches) return;
+			if (window.matchMedia('(prefers-reduced-motion: reduce)').matches) return;
+
+			var banner = document.getElementById('banner');
+			var trailPool = [
+				{ type: 'text', content: 'Golang' },
+				{ type: 'text', content: 'AWS' },
+				{ type: 'text', content: 'TypeScript' },
+				{ type: 'text', content: 'Scala' },
+				{ type: 'text', content: 'Python' },
+				{ type: 'text', content: 'OCaml' },
+				{ type: 'text', content: 'gRPC' },
+				{ type: 'text', content: 'Datadog' },
+				{ type: 'text', content: 'MongoDB' },
+				{ type: 'text', content: 'SageMaker' },
+				{ type: 'text', content: 'Temporal' },
+				{ type: 'text', content: "Cornell CS '25" },
+				{ type: 'text', content: 'Backend Eng' },
+				{ type: 'text', content: '300+ Students' },
+				{ type: 'text', content: '4 Projects' },
+				{ type: 'text', content: 'Production Systems' },
+				{ type: 'text', content: 'Snowflake' },
+				{ type: 'text', content: 'Spark' },
+				{ type: 'img', src: 'Media/AWS_Logo.png',              alt: 'AWS' },
+				{ type: 'img', src: 'Media/Coinbase_Logo_3.jpg',       alt: 'Coinbase' },
+				{ type: 'img', src: 'Media/Cornell_University_Logo.png', alt: 'Cornell' },
+				{ type: 'img', src: 'Media/CU_GeoData_Logo_2.jpg',     alt: 'GeoData' }
+			];
+			var lastX = -999, lastY = -999, minDist = 70;
+
+			banner.addEventListener('mousemove', function (e) {
+				var rect = banner.getBoundingClientRect();
+				var x = e.clientX - rect.left;
+				var y = e.clientY - rect.top;
+				if (Math.hypot(x - lastX, y - lastY) < minDist) return;
+				lastX = x; lastY = y;
+
+				var item = trailPool[Math.floor(Math.random() * trailPool.length)];
+				var el = document.createElement('span');
+
+				if (item.type === 'img') {
+					el.className = 'cursor-trail-item cursor-trail-img-item';
+					var img = document.createElement('img');
+					img.src = item.src;
+					img.alt = item.alt;
+					img.className = 'cursor-trail-img';
+					el.appendChild(img);
+				} else {
+					el.className = 'cursor-trail-item';
+					el.textContent = item.content;
+				}
+
+				el.style.left = x + 'px';
+				el.style.top = y + 'px';
+				banner.appendChild(el);
+				setTimeout(function () { if (el.parentNode) el.parentNode.removeChild(el); }, 1100);
+			});
+		})();
+		</script>
+
 		<!-- Adding a button to help bring user to top of page (using some Javascript)-->
 
 		<div>

--- a/index.html
+++ b/index.html
@@ -60,18 +60,27 @@
 				{ type: 'text', content: 'Scala' },
 				{ type: 'text', content: 'Python' },
 				{ type: 'text', content: 'OCaml' },
+				{ type: 'text', content: 'Java' },
 				{ type: 'text', content: 'gRPC' },
 				{ type: 'text', content: 'Datadog' },
 				{ type: 'text', content: 'MongoDB' },
 				{ type: 'text', content: 'SageMaker' },
 				{ type: 'text', content: 'Temporal' },
-				{ type: 'text', content: "Cornell CS '25" },
-				{ type: 'text', content: 'Backend Eng' },
+				{ type: 'text', content: 'Kubernetes' },
+				{ type: 'text', content: 'S3' },
+				{ type: 'text', content: 'Cursor' },
+				{ type: 'text', content: 'Claude' },
+				{ type: 'text', content: 'Git' },
+				{ type: 'text', content: 'Protobuf' },
+				{ type: 'text', content: 'SQL' },
+				{ type: 'text', content: 'Backend Engineer' },
 				{ type: 'text', content: '300+ Students' },
 				{ type: 'text', content: '4 Projects' },
 				{ type: 'text', content: 'Production Systems' },
 				{ type: 'text', content: 'Snowflake' },
 				{ type: 'text', content: 'Spark' },
+				{ type: 'text', content: '7 days \u2192 1 min' },
+				{ type: 'text', content: 'Millions of Users' },
 				{ type: 'img', src: 'Media/AWS_Logo.png' },
 				{ type: 'img', src: 'Media/Coinbase_Logo.jpg' },
 				{ type: 'img', src: 'Media/Cornell_University_Logo.png' },
@@ -82,7 +91,7 @@
 				{ type: 'img', src: 'Media/Amazon_Bonding_Event.jpg' },
 				{ type: 'img', src: 'Media/CU_GeoData_Data_Team_Pic.jpg' }
 			];
-			var lastX = -999, lastY = -999, minDist = 70;
+			var lastX = -999, lastY = -999, minDist = 100;
 
 			banner.addEventListener('mousemove', function (e) {
 				var rect = banner.getBoundingClientRect();


### PR DESCRIPTION
﻿## What Changed?
- Added cursor trail effect to the homepage banner section only
- As the cursor moves, badges spawn at the cursor position, float up ~52px, and fade out over 1.1s before being removed from DOM
- **Text badges** (27 items): pill-shaped skill/metric labels sourced from resume — Golang, Kubernetes, S3, Java, SQL, Protobuf, Datadog, Snowflake, Spark, gRPC, Temporal, MongoDB, SageMaker, Scala, Python, OCaml, TypeScript, AWS, Git, Cursor, Claude, Backend Engineer, 300+ Students, 4 Projects, Production Systems, 7 days → 1 min, Millions of Users
- **Image badges** (9 items): 110x80px rounded rectangles with object-fit: cover — 4 logos (AWS, Coinbase, Cornell, CU GeoData) + 5 experience photos (Coinbase group, Coinbase crypto, Coinbase office, Amazon bonding event, GeoData data team)
- Throttled by cursor distance (~100px between spawns) so badges don't flood the screen
- Scoped to #banner only — no trail effect on rest of page
- Hover-only (hover: hover media query) — no effect on touch/mobile devices
- Respects prefers-reduced-motion

## Why
Makes the banner section interactive and dynamic, surfacing resume highlights in a way that rewards cursor exploration rather than showing static text. The mix of skill tags, metrics, and experience photos gives visitors (including recruiters) a quick sense of background without reading a word.

## Files Changed
- index.html — inline mousemove script after banner section
- assets/css/main.css — cursor trail styles and trailFadeOut keyframes, position: relative on #banner

## Testing
- [x] Move cursor across the homepage banner — text and image badges should trail the cursor, float up, and fade
- [x] Badges do NOT appear outside the banner (scroll to other sections, no trail)
- [x] On mobile/touch, no trail appears
- [ ] Enable prefers-reduced-motion in OS settings — no trail
- [x] Logos display with object-fit: cover filling the rectangle cleanly

## Linear
Closes [NAT-29](https://linear.app/natan-personal/issue/NAT-29)
