### PR TITLE
feat(NAT-26): backfill missing skills across project pages from LinkedIn

### DIFF
--- a/Anomaly_Detection.html
+++ b/Anomaly_Detection.html
@@ -79,6 +79,9 @@
                 <span class="button-77">SageMaker</span>
                 <span class="button-77">AWS CLI</span>
                 <span class="button-77">QuickSight</span>
+                <li><b>Concepts</b></li>
+                <span class="button-77">Big Data Analytics</span>
+                <span class="button-77">Data Warehousing</span>
               </ul>
             </section>
 

--- a/Bridge_Quote_Simulation.html
+++ b/Bridge_Quote_Simulation.html
@@ -80,6 +80,7 @@
                 <span class="button-77">Snowflake</span>
                 <span class="button-77">gRPC APIs</span>
                 <span class="button-77">Git</span>
+                <span class="button-77">GitHub</span>
                 <span class="button-77">Jira</span>
                 <span class="button-77">Apache Superset</span>
 

--- a/CU_GeoData.html
+++ b/CU_GeoData.html
@@ -78,6 +78,13 @@
                 <span class="button-77">QGIS</span>
                 <span class="button-77">Jupyter Notebook</span>
                 <span class="button-77">OpenAI</span>
+                <span class="button-77">GitHub</span>
+                <li><b>Concepts</b></li>
+                <span class="button-77">Artificial Intelligence</span>
+                <span class="button-77">Machine Learning</span>
+                <span class="button-77">Data Analysis</span>
+                <span class="button-77">Data Visualization</span>
+                <span class="button-77">Statistics</span>
               </ul>
             </section>
 

--- a/Tax_Lot_Split.html
+++ b/Tax_Lot_Split.html
@@ -78,7 +78,13 @@
                 <span class="button-77">Temporal</span>
                 <span class="button-77">MongoDB</span>
                 <span class="button-77">Snowflake</span>
+                <span class="button-77">Kubernetes</span>
+                <span class="button-77">Protobuf</span>
+                <span class="button-77">Kafka</span>
+                <span class="button-77">Cursor</span>
+                <span class="button-77">Claude</span>
                 <span class="button-77">Git</span>
+                <span class="button-77">GitHub</span>
               </ul>
             </section>
 

--- a/assets/css/main.css
+++ b/assets/css/main.css
@@ -4845,6 +4845,14 @@ body.is-touch #banner {
 	padding: 0 0 0.75em 0;
 }
 
+#sidebar ul li:not(:first-child) {
+	margin-top: 0.75em;
+}
+
+#sidebar ul {
+	padding-bottom: 1.5em;
+}
+
 #sidebar ul li b {
 	color: white !important;
 }


### PR DESCRIPTION
﻿## What Changed?

### Skills backfilled from LinkedIn
- **CU_GeoData.html**: added GitHub (Tools); added new Concepts section: Artificial Intelligence, Machine Learning, Data Analysis, Data Visualization, Statistics
- **Anomaly_Detection.html**: added new Concepts section: Big Data Analytics, Data Warehousing
- **Tax_Lot_Split.html** (Coinbase full-time): added to Tools: Kubernetes, Protobuf, Kafka, Cursor, Claude, GitHub
- **Bridge_Quote_Simulation.html** (Coinbase intern): added GitHub to Tools
- **Cornell_TA.html**: no changes — all LinkedIn skills already present

### CSS fixes (assets/css/main.css)
- Added margin-top: 0.75em to #sidebar ul li:not(:first-child) — consistent spacing above every non-first category heading
- Added padding-bottom: 1.5em to #sidebar ul — breathing room between the last skill badge and the footer on all pages

## Why
NAT-26: audit and backfill missing skills using LinkedIn as the reference source. CSS fixes address spacing regressions introduced by adding new Concepts sections.

## Files Changed
- CU_GeoData.html
- Anomaly_Detection.html
- Tax_Lot_Split.html
- Bridge_Quote_Simulation.html
- assets/css/main.css

## Testing
- [x] CU_GeoData: GitHub, Artificial Intelligence, Machine Learning, Data Analysis, Data Visualization, Statistics all appear
- [x] Anomaly Detection: Big Data Analytics and Data Warehousing appear; Concepts heading has spacing above it; gap before footer
- [x] Tax Lot Split: Kubernetes, Protobuf, Kafka, Cursor, Claude, GitHub all appear
- [x] Bridge Quote Simulation: GitHub appears
- [x] All sidebar skills sections have consistent spacing between category headings and before the footer

## Linear
Closes [NAT-26](https://linear.app/natan-personal/issue/NAT-26)
