### PR TITLE
feat(NAT-34): add staggered entrance animations and typewriter loop to banner

### DIFF
--- a/assets/css/main.css
+++ b/assets/css/main.css
@@ -4143,6 +4143,19 @@ body.landing #header {
 	100% { opacity: 0;    transform: translate(-50%, -50%) translateY(-52px); }
 }
 
+/* Typewriter cursor */
+.tw-cursor {
+	display: inline-block;
+	font-weight: 400;
+	animation: twBlink 0.7s step-end infinite;
+	margin-left: 1px;
+}
+
+@keyframes twBlink {
+	0%, 100% { opacity: 1; }
+	50%       { opacity: 0; }
+}
+
 #banner:before {
 	content: '';
 	display: inline-block;

--- a/index.html
+++ b/index.html
@@ -135,6 +135,85 @@
 		})();
 		</script>
 
+		<script>
+		(function () {
+			if (window.matchMedia('(prefers-reduced-motion: reduce)').matches) return;
+
+			function init() {
+				var h2    = document.querySelector('#banner h2');
+				var typed = document.querySelector('#banner .typed-out');
+				var icons = document.querySelector('#banner ul.icons');
+				var img   = document.querySelector('#banner .image');
+				if (!h2 || !typed || !icons || !img) return;
+
+				var fullText = "Software Engineer | Cornell CS \u002725";
+
+				// Lock height to prevent layout shift during typewriter
+				typed.style.minHeight = typed.offsetHeight + 'px';
+
+				// Set initial hidden states
+				h2.style.cssText    += ';opacity:0;transform:translateY(32px)';
+				icons.style.cssText += ';opacity:0;transform:translateY(20px)';
+				img.style.cssText   += ';opacity:0;transform:translateX(48px)';
+				typed.style.opacity  = '0';
+
+				function reveal(el, tx, ty, ms) {
+					el.style.transition = 'opacity ' + ms + 'ms cubic-bezier(.22,1,.36,1), transform ' + ms + 'ms cubic-bezier(.22,1,.36,1)';
+					el.style.opacity    = '1';
+					el.style.transform  = 'translateX(' + tx + 'px) translateY(' + ty + 'px)';
+				}
+
+				// Staggered entrance sequence
+				setTimeout(function () { reveal(h2,    0, 0, 750); }, 150);
+				setTimeout(function () { reveal(img,   0, 0, 900); }, 450);
+				setTimeout(function () {
+					reveal(icons, 0, 0, 600);
+					startTypewriter();
+				}, 950);
+
+				// ── Typewriter ──────────────────────────────────────
+				var cursor = document.createElement('span');
+				cursor.className = 'tw-cursor';
+				cursor.textContent = '|';
+
+				function startTypewriter() {
+					typed.innerHTML = '';
+					typed.appendChild(cursor);
+					typed.style.opacity = '1';
+					typeIn(0);
+				}
+
+				function typeIn(i) {
+					if (i < fullText.length) {
+						typed.insertBefore(document.createTextNode(fullText[i]), cursor);
+						setTimeout(function () { typeIn(i + 1); }, 55);
+					} else {
+						setTimeout(erase, 3200);
+					}
+				}
+
+				function erase() {
+					var nodes = Array.prototype.slice.call(typed.childNodes).filter(function (n) { return n !== cursor; });
+					if (!nodes.length) { setTimeout(startTypewriter, 500); return; }
+					var last = nodes[nodes.length - 1];
+					if (last.textContent.length > 1) {
+						last.textContent = last.textContent.slice(0, -1);
+					} else {
+						typed.removeChild(last);
+					}
+					setTimeout(erase, 35);
+				}
+			}
+
+			// Run after the template's is-preload handling has completed
+			if (document.readyState === 'complete') {
+				setTimeout(init, 50);
+			} else {
+				window.addEventListener('load', function () { setTimeout(init, 50); });
+			}
+		})();
+		</script>
+
 		<!-- Adding a button to help bring user to top of page (using some Javascript)-->
 
 		<div>


### PR DESCRIPTION
﻿## What Changed?
Staggered entrance animations for the homepage banner, plus a looping typewriter effect for the career subtitle line.

## Sequence
1. Name (h2) slides up 32px + fades in — delay 150ms, 750ms spring curve
2. Headshot slides in from 48px right + fades in — delay 450ms, 900ms (overlaps with name)
3. Social icons slide up + fade in — delay 950ms, 600ms
4. Career line types out character by character (55ms/char) starting at 950ms
   - Blinking | cursor visible while typing
   - After full text typed, holds 3.2s, erases (35ms/char), pauses 500ms, retypes — loops forever

## Why
Makes the banner feel dynamic and polished rather than static. The stagger draws the eye naturally: name -> photo -> identity -> social. Also addresses NAT-31 (typewriter loop with no layout shift).

## Implementation Notes
- Uses cubic-bezier(.22,1,.36,1) for a natural spring deceleration (no snap)
- min-height locked on typed-out element before typewriter starts to prevent layout shift
- Runs on window load + 50ms to ensure template is-preload handling has completed first
- Fully disabled under prefers-reduced-motion

## Files Changed
- index.html: entrance animation + typewriter script block after banner section
- assets/css/main.css: .tw-cursor and @keyframes twBlink

## Testing
- [ ] On page load: name slides up, headshot slides in from right, icons + typewriter follow
- [ ] Typewriter loops: types, holds, erases, retypes continuously
- [ ] Blinking cursor visible while typing and during hold
- [ ] No layout shift (other elements don't move) during any phase
- [ ] With prefers-reduced-motion enabled: banner appears statically, no animations
- [ ] Works correctly on repeat visits (no double-animation)

## Linear
Closes [NAT-34](https://linear.app/natan-personal/issue/NAT-34)
Also closes [NAT-31](https://linear.app/natan-personal/issue/NAT-31) (typewriter loop)
